### PR TITLE
fix: check for next destination if current one is detached

### DIFF
--- a/Sources/SwiftUICoordinator/Sources/view-model/CoordinatorNavigationViewLinkModel.swift
+++ b/Sources/SwiftUICoordinator/Sources/view-model/CoordinatorNavigationViewLinkModel.swift
@@ -85,7 +85,6 @@ public class CoordinatorNavigationViewLinkModel: ObservableObject {
            !destinationWrapper.isAttached() {
             isActive = false
             self.destinationWrapper = nil
-            return
         }
         
         destinationWrapper = coordinator.destination(after: lastDestinationId)


### PR DESCRIPTION
The main reason for this change is the case when you do navigation from destination B to destination C when they are on the same level:
```swift
           /  - - - B
A - - - -
           \  - - - C
```