### PR TITLE
fix: destination switch

### DIFF
--- a/Coordinator-Example/Coordinator-Example.xcodeproj/project.pbxproj
+++ b/Coordinator-Example/Coordinator-Example.xcodeproj/project.pbxproj
@@ -17,11 +17,12 @@
 		D67B0A39276F50B400035DED /* FirstDestinationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D67B0A38276F50B400035DED /* FirstDestinationView.swift */; };
 		D67B0A3B276F50BE00035DED /* SecondDestinationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D67B0A3A276F50BE00035DED /* SecondDestinationView.swift */; };
 		D67B0A3D276F50C600035DED /* ThirdDestinationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D67B0A3C276F50C600035DED /* ThirdDestinationView.swift */; };
-		D67B0A3E276F547800035DED /* SwiftUICoordinator.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D67B0A24276E4C8E00035DED /* SwiftUICoordinator.framework */; };
-		D67B0A3F276F547800035DED /* SwiftUICoordinator.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D67B0A24276E4C8E00035DED /* SwiftUICoordinator.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		D67B0A42276F588600035DED /* Misc.swift in Sources */ = {isa = PBXBuildFile; fileRef = D67B0A41276F588600035DED /* Misc.swift */; };
 		D67B0A64277077E200035DED /* MainCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D67B0A63277077E200035DED /* MainCoordinator.swift */; };
 		D67B0A66277077EA00035DED /* MainCoordinatorImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = D67B0A65277077EA00035DED /* MainCoordinatorImpl.swift */; };
+		D6BE3C96290C1E5A0016A9E3 /* FirstDestinationBranchTwoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6BE3C95290C1E5A0016A9E3 /* FirstDestinationBranchTwoView.swift */; };
+		D6BE3C98290C1E820016A9E3 /* SecondDestinationBranchTwoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6BE3C97290C1E820016A9E3 /* SecondDestinationBranchTwoView.swift */; };
+		D6BE3C9D290C20C30016A9E3 /* SwiftUICoordinator in Frameworks */ = {isa = PBXBuildFile; productRef = D6BE3C9C290C20C30016A9E3 /* SwiftUICoordinator */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -41,20 +42,6 @@
 		};
 /* End PBXContainerItemProxy section */
 
-/* Begin PBXCopyFilesBuildPhase section */
-		D67B0A40276F547800035DED /* Embed Frameworks */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "";
-			dstSubfolderSpec = 10;
-			files = (
-				D67B0A3F276F547800035DED /* SwiftUICoordinator.framework in Embed Frameworks */,
-			);
-			name = "Embed Frameworks";
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXCopyFilesBuildPhase section */
-
 /* Begin PBXFileReference section */
 		D67B0A0B276E4C6C00035DED /* Coordinator-Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Coordinator-Example.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D67B0A0E276E4C6C00035DED /* Coordinator_ExampleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coordinator_ExampleApp.swift; sourceTree = "<group>"; };
@@ -71,6 +58,8 @@
 		D67B0A41276F588600035DED /* Misc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Misc.swift; sourceTree = "<group>"; };
 		D67B0A63277077E200035DED /* MainCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainCoordinator.swift; sourceTree = "<group>"; };
 		D67B0A65277077EA00035DED /* MainCoordinatorImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainCoordinatorImpl.swift; sourceTree = "<group>"; };
+		D6BE3C95290C1E5A0016A9E3 /* FirstDestinationBranchTwoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstDestinationBranchTwoView.swift; sourceTree = "<group>"; };
+		D6BE3C97290C1E820016A9E3 /* SecondDestinationBranchTwoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecondDestinationBranchTwoView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -78,7 +67,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D67B0A3E276F547800035DED /* SwiftUICoordinator.framework in Frameworks */,
+				D6BE3C9D290C20C30016A9E3 /* SwiftUICoordinator in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -148,8 +137,8 @@
 			isa = PBXGroup;
 			children = (
 				D67B0A38276F50B400035DED /* FirstDestinationView.swift */,
-				D67B0A3A276F50BE00035DED /* SecondDestinationView.swift */,
-				D67B0A3C276F50C600035DED /* ThirdDestinationView.swift */,
+				D6BE3C93290C1DF10016A9E3 /* branch-one */,
+				D6BE3C94290C1DF50016A9E3 /* branch-two */,
 			);
 			path = destinations;
 			sourceTree = "<group>";
@@ -163,6 +152,24 @@
 			path = coordinator;
 			sourceTree = "<group>";
 		};
+		D6BE3C93290C1DF10016A9E3 /* branch-one */ = {
+			isa = PBXGroup;
+			children = (
+				D67B0A3A276F50BE00035DED /* SecondDestinationView.swift */,
+				D67B0A3C276F50C600035DED /* ThirdDestinationView.swift */,
+			);
+			path = "branch-one";
+			sourceTree = "<group>";
+		};
+		D6BE3C94290C1DF50016A9E3 /* branch-two */ = {
+			isa = PBXGroup;
+			children = (
+				D6BE3C95290C1E5A0016A9E3 /* FirstDestinationBranchTwoView.swift */,
+				D6BE3C97290C1E820016A9E3 /* SecondDestinationBranchTwoView.swift */,
+			);
+			path = "branch-two";
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -173,13 +180,15 @@
 				D67B0A07276E4C6C00035DED /* Sources */,
 				D67B0A08276E4C6C00035DED /* Frameworks */,
 				D67B0A09276E4C6C00035DED /* Resources */,
-				D67B0A40276F547800035DED /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 			);
 			name = "Coordinator-Example";
+			packageProductDependencies = (
+				D6BE3C9C290C20C30016A9E3 /* SwiftUICoordinator */,
+			);
 			productName = "Coordinator-Example";
 			productReference = D67B0A0B276E4C6C00035DED /* Coordinator-Example.app */;
 			productType = "com.apple.product-type.application";
@@ -208,6 +217,9 @@
 				Base,
 			);
 			mainGroup = D67B0A02276E4C6C00035DED;
+			packageReferences = (
+				D6BE3C9B290C20C20016A9E3 /* XCRemoteSwiftPackageReference "SwiftUICoordinator" */,
+			);
 			productRefGroup = D67B0A0C276E4C6C00035DED /* Products */;
 			projectDirPath = "";
 			projectReferences = (
@@ -260,11 +272,13 @@
 				D67B0A34276E580A00035DED /* SecondTabView.swift in Sources */,
 				D67B0A3B276F50BE00035DED /* SecondDestinationView.swift in Sources */,
 				D67B0A36276E580F00035DED /* ThirdTabView.swift in Sources */,
+				D6BE3C96290C1E5A0016A9E3 /* FirstDestinationBranchTwoView.swift in Sources */,
 				D67B0A64277077E200035DED /* MainCoordinator.swift in Sources */,
 				D67B0A42276F588600035DED /* Misc.swift in Sources */,
 				D67B0A11276E4C6C00035DED /* ContentView.swift in Sources */,
 				D67B0A39276F50B400035DED /* FirstDestinationView.swift in Sources */,
 				D67B0A30276E580200035DED /* FirstTabView.swift in Sources */,
+				D6BE3C98290C1E820016A9E3 /* SecondDestinationBranchTwoView.swift in Sources */,
 				D67B0A66277077EA00035DED /* MainCoordinatorImpl.swift in Sources */,
 				D67B0A3D276F50C600035DED /* ThirdDestinationView.swift in Sources */,
 				D67B0A0F276E4C6C00035DED /* Coordinator_ExampleApp.swift in Sources */,
@@ -406,7 +420,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -436,7 +450,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -472,6 +486,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		D6BE3C9B290C20C20016A9E3 /* XCRemoteSwiftPackageReference "SwiftUICoordinator" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "file:///Users/jeneavn/Documents/Projects/Personal/SwiftUICoordinator";
+			requirement = {
+				branch = "fix/memory-leaks";
+				kind = branch;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		D6BE3C9C290C20C30016A9E3 /* SwiftUICoordinator */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = D6BE3C9B290C20C20016A9E3 /* XCRemoteSwiftPackageReference "SwiftUICoordinator" */;
+			productName = SwiftUICoordinator;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = D67B0A03276E4C6C00035DED /* Project object */;
 }

--- a/Coordinator-Example/Coordinator-Example.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Coordinator-Example/Coordinator-Example.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,14 @@
+{
+  "pins" : [
+    {
+      "identity" : "swiftuicoordinator",
+      "kind" : "localSourceControl",
+      "location" : ".",
+      "state" : {
+        "branch" : "fix/memory-leaks",
+        "revision" : "01a5c5505671997c181b0a88fc8d812eceecc73f"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Coordinator-Example/Coordinator-Example/ContentView.swift
+++ b/Coordinator-Example/Coordinator-Example/ContentView.swift
@@ -4,7 +4,7 @@
 //
 //  MIT License
 //
-//  Copyright (c) 2021 Jenea Vranceanu
+//  Copyright (c) 2022 Jenea Vranceanu
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/Coordinator-Example/Coordinator-Example/Coordinator_ExampleApp.swift
+++ b/Coordinator-Example/Coordinator-Example/Coordinator_ExampleApp.swift
@@ -4,7 +4,7 @@
 //
 //  MIT License
 //
-//  Copyright (c) 2021 Jenea Vranceanu
+//  Copyright (c) 2022 Jenea Vranceanu
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/Coordinator-Example/Coordinator-Example/FirstTabView.swift
+++ b/Coordinator-Example/Coordinator-Example/FirstTabView.swift
@@ -4,7 +4,7 @@
 //
 //  MIT License
 //
-//  Copyright (c) 2021 Jenea Vranceanu
+//  Copyright (c) 2022 Jenea Vranceanu
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal
@@ -28,11 +28,23 @@
 import SwiftUI
 import SwiftUICoordinator
 
+class SecondBranchHandle: ObservableObject {
+
+    var handleFunc: (() -> Void)? = nil
+
+}
+
 struct FirstTabView: View {
+
+    @StateObject private var secondBranchHandle = SecondBranchHandle()
+
+    @State var isActive = false
+
     var body: some View {
         CoordinatorNavigationView { _ in
             FirstDestinationView()
         }
+        .environmentObject(secondBranchHandle)
     }
 }
 

--- a/Coordinator-Example/Coordinator-Example/Misc.swift
+++ b/Coordinator-Example/Coordinator-Example/Misc.swift
@@ -4,7 +4,7 @@
 //
 //  MIT License
 //
-//  Copyright (c) 2021 Jenea Vranceanu
+//  Copyright (c) 2022 Jenea Vranceanu
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/Coordinator-Example/Coordinator-Example/SecondTabView.swift
+++ b/Coordinator-Example/Coordinator-Example/SecondTabView.swift
@@ -4,7 +4,7 @@
 //
 //  MIT License
 //
-//  Copyright (c) 2021 Jenea Vranceanu
+//  Copyright (c) 2022 Jenea Vranceanu
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/Coordinator-Example/Coordinator-Example/ThirdTabView.swift
+++ b/Coordinator-Example/Coordinator-Example/ThirdTabView.swift
@@ -4,7 +4,7 @@
 //
 //  MIT License
 //
-//  Copyright (c) 2021 Jenea Vranceanu
+//  Copyright (c) 2022 Jenea Vranceanu
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/Coordinator-Example/Coordinator-Example/coordinator/MainCoordinator.swift
+++ b/Coordinator-Example/Coordinator-Example/coordinator/MainCoordinator.swift
@@ -4,7 +4,7 @@
 //
 //  MIT License
 //
-//  Copyright (c) 2021 Jenea Vranceanu
+//  Copyright (c) 2022 Jenea Vranceanu
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/Coordinator-Example/Coordinator-Example/coordinator/MainCoordinatorImpl.swift
+++ b/Coordinator-Example/Coordinator-Example/coordinator/MainCoordinatorImpl.swift
@@ -4,7 +4,7 @@
 //
 //  MIT License
 //
-//  Copyright (c) 2021 Jenea Vranceanu
+//  Copyright (c) 2022 Jenea Vranceanu
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/Coordinator-Example/Coordinator-Example/destinations/branch-one/SecondDestinationView.swift
+++ b/Coordinator-Example/Coordinator-Example/destinations/branch-one/SecondDestinationView.swift
@@ -4,7 +4,7 @@
 //
 //  MIT License
 //
-//  Copyright (c) 2021 Jenea Vranceanu
+//  Copyright (c) 2022 Jenea Vranceanu
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/Coordinator-Example/Coordinator-Example/destinations/branch-one/ThirdDestinationView.swift
+++ b/Coordinator-Example/Coordinator-Example/destinations/branch-one/ThirdDestinationView.swift
@@ -4,7 +4,7 @@
 //
 //  MIT License
 //
-//  Copyright (c) 2021 Jenea Vranceanu
+//  Copyright (c) 2022 Jenea Vranceanu
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal
@@ -28,8 +28,33 @@
 import SwiftUI
 
 struct ThirdDestinationView: View {
+
+    /// An object that allows transmission of a request to replace the first branch with the second branch.
+    @EnvironmentObject private var secondBranchHandle: SecondBranchHandle
+
     var body: some View {
-        Text("Hello, World!\nFinally 💻☕️")
+        VStack {
+            Text("Hello, World!\nFinally 💻☕️")
+                .padding(32)
+
+            Text("or...")
+                .padding(8)
+
+            Button {
+                secondBranchHandle.handleFunc?()
+            } label: {
+                HStack {
+                    Text("Navigate to a destination on a different branch")
+                    Image(systemName: "arrow.triangle.branch")
+                }
+                .padding()
+                .overlay(
+                    RoundedRectangle(cornerRadius: 16)
+                        .stroke(Color.gray, lineWidth: 2)
+                )
+            }
+            .padding()
+        }
     }
 }
 

--- a/Coordinator-Example/Coordinator-Example/destinations/branch-two/FirstDestinationBranchTwoView.swift
+++ b/Coordinator-Example/Coordinator-Example/destinations/branch-two/FirstDestinationBranchTwoView.swift
@@ -1,5 +1,5 @@
 //
-//  FirstDestinationView.swift
+//  FirstDestinationBranchTwoView.swift
 //  Coordinator-Example
 //
 //  MIT License
@@ -28,14 +28,13 @@
 import SwiftUI
 import SwiftUICoordinator
 
-class FirstDestinationViewModel: ObservableObject {
+class FirstDestinationBranchTwoViewViewModel: ObservableObject {
     let id = UUID().uuidString
-    let secondDestination = SecondDestinationView().asDestination()
-    
+
     @Published var borderColor: Color = Color(red: Double.random(in: 0...1),
                                               green: Double.random(in: 0...1),
                                               blue: Double.random(in: 0...1))
-    
+
     init() {
         if TIMERS_ENABLED {
             Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { _ in
@@ -49,18 +48,17 @@ class FirstDestinationViewModel: ObservableObject {
     }
 }
 
-struct FirstDestinationView: View {
+struct FirstDestinationBranchTwoView: View {
 
-    @EnvironmentObject private var secondBranchHandle: SecondBranchHandle
-    @StateObject private var viewModel = FirstDestinationViewModel()
-    
+    @StateObject private var viewModel = FirstDestinationBranchTwoViewViewModel()
+
     var body: some View {
         CoordinatorNavigationViewLink { coordinator in
             Button {
-                coordinator.navigateTo(SecondDestinationView().asDestination())
+                coordinator.navigateTo(SecondDestinationBranchTwoView().asDestination())
             } label: {
                 HStack {
-                    Text("Navigate to second destination")
+                    Text("Navigate to second destination (branch two)")
                     Image(systemName: "2.square")
                 }
                 .padding()
@@ -69,17 +67,15 @@ struct FirstDestinationView: View {
                         .stroke(viewModel.borderColor,
                                 lineWidth: 1)
                 )
-            }.onAppear {
-                secondBranchHandle.handleFunc = {
-                    coordinator.navigateTo(FirstDestinationBranchTwoView().asDestination())
-                }
             }
+
         }
     }
 }
 
-struct FirstDestinationView_Previews: PreviewProvider {
+struct FirstDestinationBranchTwoView_Previews: PreviewProvider {
     static var previews: some View {
-        FirstDestinationView()
+        FirstDestinationBranchTwoView()
     }
 }
+

--- a/Coordinator-Example/Coordinator-Example/destinations/branch-two/SecondDestinationBranchTwoView.swift
+++ b/Coordinator-Example/Coordinator-Example/destinations/branch-two/SecondDestinationBranchTwoView.swift
@@ -1,5 +1,5 @@
 //
-//  FirstDestinationView.swift
+//  SecondDestinationBranchTwoView.swift
 //  Coordinator-Example
 //
 //  MIT License
@@ -28,14 +28,13 @@
 import SwiftUI
 import SwiftUICoordinator
 
-class FirstDestinationViewModel: ObservableObject {
+class SecondDestinationBranchTwoViewViewModel: ObservableObject {
     let id = UUID().uuidString
-    let secondDestination = SecondDestinationView().asDestination()
-    
+
     @Published var borderColor: Color = Color(red: Double.random(in: 0...1),
                                               green: Double.random(in: 0...1),
                                               blue: Double.random(in: 0...1))
-    
+
     init() {
         if TIMERS_ENABLED {
             Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { _ in
@@ -49,19 +48,18 @@ class FirstDestinationViewModel: ObservableObject {
     }
 }
 
-struct FirstDestinationView: View {
+struct SecondDestinationBranchTwoView: View {
 
-    @EnvironmentObject private var secondBranchHandle: SecondBranchHandle
-    @StateObject private var viewModel = FirstDestinationViewModel()
-    
+    @StateObject private var viewModel = SecondDestinationBranchTwoViewViewModel()
+
     var body: some View {
         CoordinatorNavigationViewLink { coordinator in
             Button {
-                coordinator.navigateTo(SecondDestinationView().asDestination())
+                coordinator.popAll()
             } label: {
                 HStack {
-                    Text("Navigate to second destination")
-                    Image(systemName: "2.square")
+                    Text("This is the end so far")
+                    Image(systemName: "figure.wave")
                 }
                 .padding()
                 .overlay(
@@ -69,17 +67,15 @@ struct FirstDestinationView: View {
                         .stroke(viewModel.borderColor,
                                 lineWidth: 1)
                 )
-            }.onAppear {
-                secondBranchHandle.handleFunc = {
-                    coordinator.navigateTo(FirstDestinationBranchTwoView().asDestination())
-                }
             }
+
         }
     }
 }
 
-struct FirstDestinationView_Previews: PreviewProvider {
+struct SecondDestinationBranchTwoView_Previews: PreviewProvider {
     static var previews: some View {
-        FirstDestinationView()
+        SecondDestinationBranchTwoView()
     }
 }
+

--- a/Sources/SwiftUICoordinator/Sources/Coordinator.swift
+++ b/Sources/SwiftUICoordinator/Sources/Coordinator.swift
@@ -42,9 +42,8 @@ open class Coordinator: ObservableObject {
     
     @Published private(set) var stack: [DestinationWrapper] = []
     private lazy var destinationHandle: DestinationHandle = {
-        DestinationHandle { destinationWrapper in
-            destinationWrapper.detach(self.destinationHandle)
-            guard let idx = self.stack.firstIndex(of: destinationWrapper) else { return }
+        DestinationHandle { [weak self] destinationWrapper in
+            guard let self = self, let idx = self.stack.firstIndex(of: destinationWrapper) else { return }
             self.stack.remove(at: idx)
             self.postNotificationStackUpdate()
         }
@@ -53,14 +52,15 @@ open class Coordinator: ObservableObject {
     /**
      Debouncer for preventing multiple stack notifications in a short period of time, e.g. when popping all destinations to root.
      */
-    private lazy var stackUpdateDebouncer = {
-        Debouncer {
-            NotificationCenter.default.post(name: COORDINATOR_STACK_NOTIFICATION, object: nil, userInfo: [NAVIGATION_STACK_ID: self.id])
-        }
-    }()
+    private let stackUpdateDebouncer: Debouncer
     
     public init(id: NavigationStackId) {
         self.id = id
+        stackUpdateDebouncer = Debouncer {
+            NotificationCenter.default.post(name: COORDINATOR_STACK_NOTIFICATION,
+                                            object: nil,
+                                            userInfo: [NAVIGATION_STACK_ID: id])
+        }
     }
     
     public func getId() -> NavigationStackId {

--- a/Sources/SwiftUICoordinator/Sources/Coordinator.swift
+++ b/Sources/SwiftUICoordinator/Sources/Coordinator.swift
@@ -98,9 +98,9 @@ open class Coordinator: ObservableObject {
 
         if let index = stack.firstIndex(of: destinationWrapper) {
             let lastIndex = stack.count - 1
-            if index < lastIndex {
+            if index < lastIndex && !onlySwap {
                 let removeCount = lastIndex - index
-                stack[(index + 1)...lastIndex].forEach { $0.detach(destinationHandle) }
+                stack[index + 1].detach(destinationHandle)
                 stack.removeLast(removeCount)
             }
             stack[index] = destinationWrapper

--- a/Sources/SwiftUICoordinator/Sources/Coordinator.swift
+++ b/Sources/SwiftUICoordinator/Sources/Coordinator.swift
@@ -97,10 +97,10 @@ open class Coordinator: ObservableObject {
         destinationWrapper.attach(destinationHandle)
 
         if let index = stack.firstIndex(of: destinationWrapper) {
-            let size = stack.count - 1
-            if index < size {
-                let removeCount = size - (index + 1)
-                stack[(index + 1)...size].forEach { $0.detach(destinationHandle) }
+            let lastIndex = stack.count - 1
+            if index < lastIndex {
+                let removeCount = lastIndex - index
+                stack[(index + 1)...lastIndex].forEach { $0.detach(destinationHandle) }
                 stack.removeLast(removeCount)
             }
             stack[index] = destinationWrapper

--- a/Sources/SwiftUICoordinator/Sources/Coordinator.swift
+++ b/Sources/SwiftUICoordinator/Sources/Coordinator.swift
@@ -96,7 +96,7 @@ open class Coordinator: ObservableObject {
         
         destinationWrapper.attach(destinationHandle)
 
-        if let index = stack.firstIndex(of: destinationWrapper) {
+        if let index = stack.firstIndex(where: { $0.id == destinationWrapper.id }) {
             let lastIndex = stack.count - 1
             if index < lastIndex && !onlySwap {
                 let removeCount = lastIndex - index
@@ -116,12 +116,20 @@ open class Coordinator: ObservableObject {
      If this wrapper is not in the stack of this coordinator calling this function has no effect,
      */
     public func popTo(_ dw: DestinationWrapper) {
-        guard let index = stack.firstIndex(of: dw) else { return }
+        popTo(dw.id)
+    }
+
+    public func popTo(_ destinationId: String) {
+        popTo(DestinationID(destinationId))
+    }
+
+    public func popTo(_ destinationId: DestinationID) {
+        guard let index = stack.firstIndex(where: { $0.id == destinationId }) else { return }
         stack[index..<stack.count].forEach { destination in
             destination.detach(destinationHandle)
         }
         stack = stack.dropLast(stack.count - index)
-        
+
         postNotificationStackUpdate()
     }
     
@@ -170,8 +178,7 @@ open class Coordinator: ObservableObject {
     }
     
     public func isTopOfTheStack(_ destinationWrapper: DestinationWrapper?) -> Bool {
-        guard let destinationWrapper = destinationWrapper else { return false }
-        return (stack.firstIndex(of: destinationWrapper) ?? 0) >= stack.count-1
+        destinationWrapper != nil && stack.last?.id == destinationWrapper?.id
     }
     
     private func postNotificationStackUpdate() {

--- a/Sources/SwiftUICoordinator/Sources/destination/Destination.swift
+++ b/Sources/SwiftUICoordinator/Sources/destination/Destination.swift
@@ -65,12 +65,24 @@ public class DestinationCreator {
     }
 }
 
-public class DestinationID: ObservableObject, Equatable, Hashable {
+public class DestinationID: ObservableObject,
+                            Equatable,
+                            Hashable,
+                            CustomStringConvertible,
+                            CustomDebugStringConvertible {
     public static func == (lhs: DestinationID, rhs: DestinationID) -> Bool {
         lhs.id == rhs.id
     }
     
     public let id: String
+
+    public var description: String {
+        debugDescription
+    }
+
+    public var debugDescription: String {
+        id
+    }
     
     public init(_ id: String = UUID().uuidString) {
         self.id = id

--- a/Sources/SwiftUICoordinator/Sources/destination/Destination.swift
+++ b/Sources/SwiftUICoordinator/Sources/destination/Destination.swift
@@ -33,7 +33,7 @@ import SwiftUI
  */
 public class DestinationHandle: Equatable {
     public static func == (lhs: DestinationHandle, rhs: DestinationHandle) -> Bool {
-        return lhs.id == rhs.id
+        lhs.id == rhs.id
     }
     
     public let id = UUID()
@@ -67,7 +67,7 @@ public class DestinationCreator {
 
 public class DestinationID: ObservableObject, Equatable, Hashable {
     public static func == (lhs: DestinationID, rhs: DestinationID) -> Bool {
-        return lhs.id == rhs.id
+        lhs.id == rhs.id
     }
     
     public let id: String
@@ -86,7 +86,7 @@ public class DestinationID: ObservableObject, Equatable, Hashable {
  */
 public class DestinationWrapper: ObservableObject, Equatable, Hashable {
     public static func == (lhs: DestinationWrapper, rhs: DestinationWrapper) -> Bool {
-        return lhs.id == rhs.id
+        lhs.id == rhs.id
     }
     
     public let id: DestinationID
@@ -106,17 +106,14 @@ public class DestinationWrapper: ObservableObject, Equatable, Hashable {
         }
     }()
     
-    public init(_ destinationCreator: DestinationCreator) {
+    public init(id: DestinationID = DestinationID(), _ destinationCreator: DestinationCreator) {
+        self.id = id
         self.destinationCreator = destinationCreator
-        id = DestinationID()
     }
     
-    /**
-     If the destination is dynamic, meaning it depends on the input, make sure that this input always has the same ID.
-     */
-    public init(_ destinationCreator: DestinationCreator, id: String) {
-        self.destinationCreator = destinationCreator
-        self.id = DestinationID(id)
+    /// If the destination is dynamic, meaning it depends on the input, make sure that this input always has the same ID.
+    public convenience init(id: String, _ destinationCreator: DestinationCreator) {
+        self.init(id: DestinationID(id), destinationCreator)
     }
     
     public func isAttached() -> Bool {

--- a/Sources/SwiftUICoordinator/Sources/destination/Destination.swift
+++ b/Sources/SwiftUICoordinator/Sources/destination/Destination.swift
@@ -51,12 +51,14 @@ public class DestinationHandle: Equatable {
 /**
  Wrapper for View creation.
  */
-public class DestinationCreator {
-    
+public class DestinationCreator{
+
+    internal let viewDescription: String
     private let instance: () -> AnyView
     
-    public init(_ instance: @escaping () -> AnyView) {
+    public init(_ instance: @escaping () -> AnyView, viewDescription: String) {
         self.instance = instance
+        self.viewDescription = viewDescription
     }
     
     @ViewBuilder
@@ -98,7 +100,7 @@ public class DestinationID: ObservableObject,
  */
 public class DestinationWrapper: ObservableObject, Equatable, Hashable {
     public static func == (lhs: DestinationWrapper, rhs: DestinationWrapper) -> Bool {
-        lhs.id == rhs.id
+        lhs.id == rhs.id && lhs.destinationCreator.viewDescription == rhs.destinationCreator.viewDescription
     }
     
     public let id: DestinationID

--- a/Sources/SwiftUICoordinator/Sources/destination/View+DestinationExtension.swift
+++ b/Sources/SwiftUICoordinator/Sources/destination/View+DestinationExtension.swift
@@ -31,9 +31,9 @@ import SwiftUI
 
 public extension View {
     func asDestination(_ id: DestinationID) -> DestinationWrapper {
-        DestinationWrapper(id: id, DestinationCreator({
-            AnyView(self)
-        }))
+        DestinationWrapper(id: id, DestinationCreator({ AnyView(self) },
+                                                      /// `type(of:...)` doesn't look like a reliable long term solution
+                                                      viewDescription: "\(type(of: self))"))
     }
 
     func asDestination(_ id: String = UUID().uuidString) -> DestinationWrapper {

--- a/Sources/SwiftUICoordinator/Sources/destination/View+DestinationExtension.swift
+++ b/Sources/SwiftUICoordinator/Sources/destination/View+DestinationExtension.swift
@@ -30,9 +30,13 @@ import Foundation
 import SwiftUI
 
 public extension View {
-    func asDestination() -> DestinationWrapper {
-        DestinationWrapper(DestinationCreator({
+    func asDestination(_ id: DestinationID) -> DestinationWrapper {
+        DestinationWrapper(id: id, DestinationCreator({
             AnyView(self)
         }))
+    }
+
+    func asDestination(_ id: String = UUID().uuidString) -> DestinationWrapper {
+        asDestination(DestinationID(id))
     }
 }

--- a/Sources/SwiftUICoordinator/Sources/view-model/CoordinatorNavigationViewLinkModel.swift
+++ b/Sources/SwiftUICoordinator/Sources/view-model/CoordinatorNavigationViewLinkModel.swift
@@ -80,17 +80,24 @@ public class CoordinatorNavigationViewLinkModel: ObservableObject {
             // Should ignore this notification.
             return
         }
-        
-        if let destinationWrapper = destinationWrapper,
-           !destinationWrapper.isAttached() {
-            isActive = false
-            self.destinationWrapper = nil
+
+        let newDestination = coordinator.destination(after: lastDestinationId)
+
+        if let currentDestination = destinationWrapper {
+            if let newDestination = newDestination,
+               currentDestination != newDestination {
+                self.destinationWrapper = newDestination
+            } else !currentDestination.isAttached() {
+                self.destinationWrapper = nil
+                isActive = false
+                return
+            }
+        } else {
+            self.destinationWrapper = newDestination
         }
-        
-        destinationWrapper = coordinator.destination(after: lastDestinationId)
-        let isActive = coordinator.isActive(destinationWrapper)
-        if isActive {
-            self.isActive = isActive
+
+        if coordinator.isActive(destinationWrapper) {
+            isActive = true
         }
     }
     

--- a/Sources/SwiftUICoordinator/Sources/view-model/CoordinatorNavigationViewLinkModel.swift
+++ b/Sources/SwiftUICoordinator/Sources/view-model/CoordinatorNavigationViewLinkModel.swift
@@ -81,13 +81,13 @@ public class CoordinatorNavigationViewLinkModel: ObservableObject {
             return
         }
 
-        let newDestination = coordinator.destination(after: lastDestinationId)
+        let newDestination: DestinationWrapper? = coordinator.destination(after: lastDestinationId)
 
         if let currentDestination = destinationWrapper {
             if let newDestination = newDestination,
                currentDestination != newDestination {
                 self.destinationWrapper = newDestination
-            } else !currentDestination.isAttached() {
+            } else if !currentDestination.isAttached() {
                 self.destinationWrapper = nil
                 isActive = false
                 return


### PR DESCRIPTION
Fixes for correct switching between destinations.
Specifically resolves the issue when whole branches are changed, e.g.:
```
         / -> Destination A -> B -> C
root ->
         \ -> Destination E -> F
```

It must be possible to switch from C to E and F without the need to pop A and B before switching to E.